### PR TITLE
Integrate More Mob Heads and Even More Mob Heads

### DIFF
--- a/src/main/java/net/darkmorford/btweagles/BetterThanWeagles.java
+++ b/src/main/java/net/darkmorford/btweagles/BetterThanWeagles.java
@@ -7,6 +7,7 @@ import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.util.EnumHelper;
+import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.common.Mod.EventHandler;
 import net.minecraftforge.fml.common.SidedProxy;
@@ -64,6 +65,9 @@ public class BetterThanWeagles
 	@EventHandler
 	public void init(FMLInitializationEvent event)
 	{
+		MinecraftForge.EVENT_BUS.register(new LootTableInjector());
+		MinecraftForge.EVENT_BUS.register(new EvenMoreMobHeads());
+
 		proxy.init(event);
 	}
 

--- a/src/main/java/net/darkmorford/btweagles/EvenMoreMobHeads.java
+++ b/src/main/java/net/darkmorford/btweagles/EvenMoreMobHeads.java
@@ -1,0 +1,174 @@
+package net.darkmorford.btweagles;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.boss.EntityWither;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.monster.EntityZombieVillager;
+import net.minecraft.entity.passive.*;
+import net.minecraft.init.Items;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import net.minecraftforge.event.entity.living.LivingDropsEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+public class EvenMoreMobHeads
+{
+	static final Map<String, ItemStack> HEADS = buildHeads();
+
+	static final List<ItemStack> WITHER_HEADS = ImmutableList.of(
+			skull("Wither", "119c371b-ea16-47c9-ad7f-23b3d894520a", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2RmNzRlMzIzZWQ0MTQzNjk2NWY1YzU3ZGRmMjgxNWQ1MzMyZmU5OTllNjhmYmI5ZDZjZjVjOGJkNDEzOWYifX19"),
+			skull("Wither Invulnerable", "b6c43469-8904-4855-a024-813ac28aa2a5", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvM2U0ZjQ5NTM1YTI3NmFhY2M0ZGM4NDEzM2JmZTgxYmU1ZjJhNDc5OWE0YzA0ZDlhNGRkYjcyZDgxOWVjMmIyYiJ9fX0="),
+			skull("Wither", "d532e209-ea0b-43da-a67d-4b735274e03c", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTY0ZTFjM2UzMTVjOGQ4ZmZmYzM3OTg1YjY2ODFjNWJkMTZhNmY5N2ZmZDA3MTk5ZThhMDVlZmJlZjEwMzc5MyJ9fX0="),
+			skull("Wither Invulnerable", "6943ecc3-4ffb-4d2d-803d-528eb5e9f6b6", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGRhZmIyM2VmYzU3ZjI1MTg3OGU1MzI4ZDExY2IwZWVmODdiNzljODdiMjU0YTdlYzcyMjk2ZjkzNjNlZjdjIn19fQ==")
+	);
+
+	protected static ItemStack skull(String name, String owner, String texture)
+	{
+		ItemStack stack = new ItemStack(Items.SKULL, 1, 3);
+
+		NBTTagCompound display = new NBTTagCompound();
+		display.setString("LocName", name);
+		stack.setTagInfo("display", display);
+
+		NBTTagCompound skullOwner = new NBTTagCompound();
+		skullOwner.setString("Id", owner);
+		NBTTagCompound properties = new NBTTagCompound();
+		NBTTagList textures = new NBTTagList();
+		NBTTagCompound tex = new NBTTagCompound();
+		tex.setString("Value", texture);
+		textures.appendTag(tex);
+		properties.setTag("textures", textures);
+		skullOwner.setTag("Properties", properties);
+		stack.setTagInfo("SkullOwner", skullOwner);
+
+		return stack;
+	}
+
+	protected static Map<String, ItemStack> buildHeads()
+	{
+		ImmutableMap.Builder heads = ImmutableMap.builder();
+
+		heads.put("minecraft:zombie_villager;minecraft:farmer", skull("Zombie Farmer Head", "1c067ee0-f090-4f79-89f1-51b87eafa257", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2ZmMDQ4MmZkMzJmYWIyY2U5ZjVmYTJlMmQ5YjRkYzc1NjFkYTQyMjE1MmM5OWZjODA0YjkxMzljYWYyNTZiIn19fQ=="));
+		heads.put("minecraft:zombie_villager;minecraft:librarian", skull("Zombie Librarian Head", "17ecf859-a648-4b01-8d9c-c1403e68f680", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDRmMDhlYmQ0ZTI1Y2RhM2FkZTQ1Yjg2MzM3OGFkMzc3ZjE4YzUxMGRiNGQyOGU4MmJiMjQ0NTE0MzliMzczNCJ9fX0="));
+		heads.put("minecraft:zombie_villager;minecraft:priest", skull("Zombie Priest Head", "3b980c41-7ce1-4a76-b275-6ed00cd6e98b", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTI4YzJiYWQ1Mzg5Y2IzNTkyYjU2NWIzYzQ3ZWNjMTg5ZTA1NDJhODc4MzUwMjhkNjE0OGJiZTMzNDU2NDUifX19"));
+		heads.put("minecraft:zombie_villager;minecraft:smith", skull("Zombie Smith Head", "7dfcfd39-21d8-4e18-8ec2-f49185562f84", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYTE2MTU1ZmNmMzY2Y2Y0ZTA2Y2U1ZGZmYzQ4Y2E1NGU4ZWE0OGRmZTUyNTM1OGI2MTJkYzQ0ZmQ0MzIifX19"));
+		heads.put("minecraft:zombie_villager;minecraft:butcher", skull("Zombie Butcher Head", "8315d5a2-1465-4160-a689-ecf2d91dd15d", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTYxZjE5ZmZkOGFlNDI1NzkyYzRiMTgxNzU2YWRmZjhkNDgxNzRhZWVmNThhMGYzMjdhMjhjNzQyYzcyNDQyIn19fQ=="));
+		heads.put("minecraft:zombie_villager;minecraft:nitwit", skull("Zombie Nitwit Head", "bcaf2b85-d421-47cc-a40a-455e77bfb60b", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzdlODM4Y2NjMjY3NzZhMjE3YzY3ODM4NmY2YTY1NzkxZmU4Y2RhYjhjZTljYTRhYzZiMjgzOTdhNGQ4MWMyMiJ9fX0="));
+
+		heads.put("minecraft:llama;0", skull("Creamy Llama Head", "dd0a3919-e919-428c-9298-6dcc416fec9d", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNGQ2N2ZkNGJmZjI5MzI2OWNiOTA4OTc0ZGNhODNjMzM0ODVlNDM1ZWQ1YThlMWRiZDY1MjFjNjE2ODcxNDAifX19"));
+		heads.put("minecraft:llama;1", skull("White Llama Head", "60d7893f-b634-48b8-8d6e-f07fa14f5115", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODAyNzdlNmIzZDlmNzgxOWVmYzdkYTRiNDI3NDVmN2FiOWE2M2JhOGYzNmQ2Yjg0YTdhMjUwYzZkMWEzNThlYiJ9fX0="));
+		heads.put("minecraft:llama;2", skull("Brown Llama Head", "75fb08e5-2419-46fa-bf09-57362138f234", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzJiMWVjZmY3N2ZmZTNiNTAzYzMwYTU0OGViMjNhMWEwOGZhMjZmZDY3Y2RmZjM4OTg1NWQ3NDkyMTM2OCJ9fX0="));
+		heads.put("minecraft:llama;3", skull("Gray Llama Head", "edca7a0d-770f-43d6-8ffc-f6a00e94e477", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2YyNGU1NmZkOWZmZDcxMzNkYTZkMWYzZTJmNDU1OTUyYjFkYTQ2MjY4NmY3NTNjNTk3ZWU4MjI5OWEifX19"));
+
+		heads.put("minecraft:ocelot;0", skull("Ocelot Head", "664dd492-3fcd-443b-9e61-4c7ebd9e4e10", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTY1N2NkNWMyOTg5ZmY5NzU3MGZlYzRkZGNkYzY5MjZhNjhhMzM5MzI1MGMxYmUxZjBiMTE0YTFkYjEifX19"));
+		heads.put("minecraft:ocelot;1", skull("Black Cat Head", "82cf1e27-3b94-4f81-9f4a-d79f4b4b0a2a", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZjJhNjYyZjJhZTdkZWJlZTY1MjkyYzJiZjQyZmJiMDliOTdiMmZmYmRiMjcwNTIwYzJkYjk2ZTUxZDg5NDUifX19"));
+		heads.put("minecraft:ocelot;2", skull("Ginger Cat Head", "4b386bcf-a8e6-4461-b738-d5427bae49ad", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYTc1NWU3ZGYwNGQxOGIzMWQ2M2MxN2Y0YTdiNGM3MzkyNGJkNjI2NWRhNjllMTEzZWRkZDk3NTE2ZmM3In19fQ=="));
+		heads.put("minecraft:ocelot;3", skull("Siamese Cat Head", "1775ad8a-06ac-4d62-a21b-593dcfcd2192", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYWI4ODFjMzliM2FmZGNjNzlmOTFmZTVkZTNjZGQwMTViYzMzNTM4NDNmNTkxZjRkMjNjZDMwMjdkZTRlNiJ9fX0="));
+
+		heads.put("minecraft:rabbit;Toast", skull("Toast Rabbit Head", "4e03f384-b31f-4803-8d74-801ecdf78869", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzJmYzNiNzQ2NjY1NDVmMmQ0MWJjMmI1MzQwZTFkZjY5ZGQyNWUyYTdlMmIzNGVmZDFhOTUzMTFhN2Q2YyJ9fX0="));
+		heads.put("minecraft:rabbit;0", skull("Brown Rabbit Head", "2186bdc6-55b1-4b44-8a46-3c8a11d40f3d", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvN2QxMTY5YjI2OTRhNmFiYTgyNjM2MDk5MjM2NWJjZGE1YTEwYzg5YTNhYTJiNDhjNDM4NTMxZGQ4Njg1YzNhNyJ9fX0="));
+		heads.put("minecraft:rabbit;1", skull("White Rabbit Head", "1288e126-41dd-4608-b304-86d84464d5e4", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTU0MmQ3MTYwOTg3MTQ4YTVkOGUyMGU0NjliZDliM2MyYTM5NDZjN2ZiNTkyM2Y1NWI5YmVhZTk5MTg1ZiJ9fX0="));
+		heads.put("minecraft:rabbit;2", skull("Black Rabbit Head", "827f5a8f-1cd7-4148-872f-d3c7f424882f", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzJjNTgxMTZhMTQ3ZDFhOWEyNjI2OTIyNGE4YmUxODRmZThlNWYzZjNkZjliNjE3NTEzNjlhZDg3MzgyZWM5In19fQ=="));
+		heads.put("minecraft:rabbit;3", skull("Black And White Rabbit Head", "6bafd710-5fa3-4f4d-99cf-ad47fa436e3f", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2I4Y2ZmNGIxNWI4Y2EzN2UyNTc1MGYzNDU3MThmMjg5Y2IyMmM1YjNhZDIyNjI3YTcxMjIzZmFjY2MifX19"));
+		heads.put("minecraft:rabbit;4", skull("Gold Rabbit Head", "dacb90db-f547-4b25-b9fd-c2aefc0b07fa", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYzk3N2EzMjY2YmYzYjllYWYxN2U1YTAyZWE1ZmJiNDY4MDExNTk4NjNkZDI4OGI5M2U2YzEyYzljYiJ9fX0="));
+		heads.put("minecraft:rabbit;5", skull("Salt And Pepper Rabbit Head", "02703b0c-573f-4042-a91b-659a3981b508", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZmZlY2M2YjVlNmVhNWNlZDc0YzQ2ZTc2MjdiZTNmMDgyNjMyN2ZiYTI2Mzg2YzZjYzc4NjMzNzJlOWJjIn19fQ=="));
+
+		heads.put("minecraft:parrot;0", skull("Red Parrot Head", "d890586d-3e18-41fc-a93d-9040dc25409b", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYTRiYThkNjZmZWNiMTk5MmU5NGI4Njg3ZDZhYjRhNTMyMGFiNzU5NGFjMTk0YTI2MTVlZDRkZjgxOGVkYmMzIn19fQ=="));
+		heads.put("minecraft:parrot;1", skull("Blue Parrot Head", "3ac775c2-c701-4ccd-bec2-5cc7a5c0bb7a", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYWNhNTgwYjA1MWM2M2JlMjlkYTU0NWE5YWE3ZmY3ZTEzNmRmNzdhODFjNjdkYzFlZTllNjE3MGMxNGZiMzEwIn19fQ=="));
+		heads.put("minecraft:parrot;2", skull("Green Parrot Head", "b95a9198-cf0b-4cfa-bf6d-2f172dc6ee65", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYWI5YTM2YzU1ODlmM2EyZTU5YzFjYWE5YjNiODhmYWRhNzY3MzJiZGI0YTc5MjYzODhhOGMwODhiYmJjYiJ9fX0="));
+		heads.put("minecraft:parrot;3", skull("Cyan Parrot Head", "0bd02c77-cd3f-4bf4-9d02-89cd7f58e06c", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMmI5NGYyMzZjNGE2NDJlYjJiY2RjMzU4OWI5YzNjNGEwYjViZDVkZjljZDVkNjhmMzdmOGM4M2Y4ZTNmMSJ9fX0="));
+		heads.put("minecraft:parrot;4", skull("Gray Parrot Head", "2a8680dd-7875-4c83-810a-5b866a3d4433", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvM2Q2ZjRhMjFlMGQ2MmFmODI0Zjg3MDhhYzYzNDEwZjFhMDFiYmI0MWQ3ZjRhNzAyZDk0NjljNjExMzIyMiJ9fX0="));
+
+		heads.put("minecraft:horse;0", skull("White Horse Head", "d941cb68-8842-4f78-bdf8-5f1d3c6e7ac0", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjBhMmRiMmYxZWI5M2U1OTc4ZDJkYzkxYTc0ZGY0M2Q3Yjc1ZDllYzBlNjk0ZmQ3ZjJhNjUyZmJkMTUifX19"));
+		heads.put("minecraft:horse;1", skull("Creamy Horse Head", "65e8bd32-6f48-4b92-ab48-fe1add6b67d1", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjI4ZDFhYjRiZTFlMjhiN2I0NjFmZGVhNDYzODFhYzM2M2E3ZTVjMzU5MWM5ZTVkMjY4M2ZiZTFlYzlmY2QzIn19fQ=="));
+		heads.put("minecraft:horse;2", skull("Chestnut Horse Head", "5a2546e1-2213-4f2a-8cbe-5ffddf3e7269", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjY2YjJiMzJkMzE1MzljNzM4M2Q5MjNiYWU0ZmFhZjY1ZGE2NzE1Y2Q1MjZjMzVkMmU0ZTY4MjVkYTExZmIifX19"));
+		heads.put("minecraft:horse;3", skull("Brown Horse Head", "2dcb4f55-ab85-48ba-b7d2-7b57d3ec7bfa", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOGE1ZmFiYmNiYzU0ODE5NzZmYjkzOGE1MTllYWQ1OWVlZWUyYTA3MWRmMjk3Mzg0YThmZTk2Nzg4YTlkZjVhNiJ9fX0="));
+		heads.put("minecraft:horse;4", skull("Black Horse Head", "4083cd58-1325-4bfa-9efb-5b8b93a02493", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjRiN2ZjNWY3YTlkZGZkZDFhYTc5MzE3NDEwZmMxOTI5ZjkxYmRkZjk4NTg1OTM4YTJhNTYxOTlhNjMzY2MifX19"));
+		heads.put("minecraft:horse;5", skull("Gray Horse Head", "b600f9c3-9c3f-4e3c-828c-3ebb6414eaa7", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDEzODEzZGQ0NWVkMGVmODM4NDQ4Y2Y2ZjYzMWMxNTdjMjNmOTY1MGM1YWU0NTFlOTc4YTUzMzgzMzEyZmUifX19"));
+		heads.put("minecraft:horse;6", skull("Dark Brown Horse Head", "c6abc94e-a5ff-45fe-a0d7-4e479f290a6f", "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDJlYjk2N2FiOTRmZGQ0MWE2MzI1ZjEyNzdkNmRjMDE5MjI2ZTVjZjM0OTc3ZWVlNjk1OTdmYWZjZjVlIn19fQ=="));
+
+		return heads.build();
+	}
+
+	public EvenMoreMobHeads()
+	{
+	}
+
+	@SubscribeEvent
+	public void somethingDied(LivingDropsEvent event)
+	{
+		if (!"player".equals(event.getSource().damageType))
+		{
+			return;
+		}
+
+		EntityLivingBase entity = event.getEntityLiving();
+		int looting = event.getLootingLevel();
+		Random rng = entity.getEntityWorld().rand;
+
+		ItemStack skull = null;
+
+		if (entity instanceof EntityZombieVillager)
+		{
+			if (rng.nextFloat() < 0.025 + looting * 0.01)
+			{
+				skull = HEADS.get("minecraft:zombie_villager;" + ((EntityZombieVillager) entity).getForgeProfession().getRegistryName().toString());
+			}
+		}
+		else if (entity instanceof EntityLlama)
+		{
+			if (rng.nextFloat() < 0.025 + looting * 0.01)
+			{
+				skull = HEADS.get("minecraft:llama;" + ((EntityLlama) entity).getVariant());
+			}
+		}
+		else if (entity instanceof EntityOcelot)
+		{
+			if (rng.nextFloat() < 0.05 + looting * 0.02)
+			{
+				skull = HEADS.get("minecraft:ocelot;" + ((EntityOcelot) entity).getTameSkin());
+			}
+		}
+		else if (entity instanceof EntityRabbit)
+		{
+			if (rng.nextFloat() < 0.1 + looting * 0.05)
+			{
+				if ("Toast".equals(entity.getCustomNameTag()))
+				{
+					skull = HEADS.get("minecraft:rabbit;Toast");
+				}
+				else
+				{
+					skull = HEADS.get("minecraft:rabbit;" + ((EntityRabbit) entity).getRabbitType());
+				}
+			}
+		}
+		else if (entity instanceof EntityParrot)
+		{
+			skull = HEADS.get("minecraft:parrot;" + ((EntityParrot) entity).getVariant());
+		}
+		else if (entity instanceof EntityHorse)
+		{
+			if (rng.nextFloat() < 0.2 + looting * 0.1)
+			{
+				skull = HEADS.get("minecraft:horse;" + ((EntityHorse) entity).getHorseVariant() % 256);
+			}
+		}
+		else if (entity instanceof EntityWither)
+		{
+			skull = WITHER_HEADS.get(entity.getEntityWorld().rand.nextInt(WITHER_HEADS.size()));
+		}
+
+		if (skull != null)
+		{
+			event.getDrops().add(new EntityItem(entity.getEntityWorld(), entity.getPosition().getX(), entity.getPosition().getY(), entity.getPosition().getZ(), skull.copy()));
+		}
+	}
+}

--- a/src/main/java/net/darkmorford/btweagles/LootTableInjector.java
+++ b/src/main/java/net/darkmorford/btweagles/LootTableInjector.java
@@ -1,0 +1,110 @@
+package net.darkmorford.btweagles;
+
+import com.google.common.collect.ImmutableSet;
+import net.minecraft.util.ResourceLocation;
+import net.minecraft.world.storage.loot.*;
+import net.minecraftforge.event.LootTableLoadEvent;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+
+import java.util.Set;
+
+public class LootTableInjector
+{
+	public final static int MAX_POOLS = 3;
+
+	public final static Set<String> INJECTED_LOOT_TABLES = ImmutableSet.of(
+		"inject/minecraft/chests/abandoned_mineshaft",
+		"inject/minecraft/chests/desert_pyramid",
+		"inject/minecraft/chests/end_city_treasure",
+		"inject/minecraft/chests/igloo_chest",
+		"inject/minecraft/chests/jungle_temple",
+		"inject/minecraft/chests/nether_bridge",
+		"inject/minecraft/chests/simple_dungeon",
+		"inject/minecraft/chests/stronghold_corridor",
+		"inject/minecraft/chests/stronghold_crossing",
+		"inject/minecraft/chests/stronghold_library",
+		"inject/minecraft/chests/village_blacksmith",
+		"inject/minecraft/chests/woodland_mansion",
+		"inject/minecraft/entities/sheep/black",
+		"inject/minecraft/entities/sheep/blue",
+		"inject/minecraft/entities/sheep/brown",
+		"inject/minecraft/entities/sheep/cyan",
+		"inject/minecraft/entities/sheep/gray",
+		"inject/minecraft/entities/sheep/green",
+		"inject/minecraft/entities/sheep/light_blue",
+		"inject/minecraft/entities/sheep/lime",
+		"inject/minecraft/entities/sheep/magenta",
+		"inject/minecraft/entities/sheep/orange",
+		"inject/minecraft/entities/sheep/pink",
+		"inject/minecraft/entities/sheep/purple",
+		"inject/minecraft/entities/sheep/red",
+		"inject/minecraft/entities/sheep/silver",
+		"inject/minecraft/entities/sheep/white",
+		"inject/minecraft/entities/sheep/yellow",
+		"inject/minecraft/entities/bat",
+		"inject/minecraft/entities/ender_dragon",
+		"inject/minecraft/entities/endermite",
+		"inject/minecraft/entities/silverfish",
+		"inject/minecraft/entities/vex",
+		"inject/minecraft/entities/wolf",
+		"inject/minecraft/entities/cow",
+		"inject/minecraft/entities/blaze",
+		"inject/minecraft/entities/cave_spider",
+		"inject/minecraft/entities/chicken",
+		"inject/minecraft/entities/donkey",
+		"inject/minecraft/entities/elder_guardian",
+		"inject/minecraft/entities/enderman",
+		"inject/minecraft/entities/evocation_illager",
+		"inject/minecraft/entities/ghast",
+		"inject/minecraft/entities/guardian",
+		"inject/minecraft/entities/husk",
+		"inject/minecraft/entities/iron_golem",
+		"inject/minecraft/entities/magma_cube",
+		"inject/minecraft/entities/mushroom_cow",
+		"inject/minecraft/entities/pig",
+		"inject/minecraft/entities/polar_bear",
+		"inject/minecraft/entities/shulker",
+		"inject/minecraft/entities/slime",
+		"inject/minecraft/entities/snowman",
+		"inject/minecraft/entities/spider",
+		"inject/minecraft/entities/squid",
+		"inject/minecraft/entities/stray",
+		"inject/minecraft/entities/villager",
+		"inject/minecraft/entities/vindication_illager",
+		"inject/minecraft/entities/witch",
+		"inject/minecraft/entities/zombie_pigman",
+		"inject/minecraft/gameplay/fishing"
+	);
+	public LootTableInjector()
+	{
+		for (String path: LootTableInjector.INJECTED_LOOT_TABLES)
+		{
+			LootTableList.register(new ResourceLocation(BetterThanWeagles.MODID, path));
+		}
+
+		LootTableList.register(new ResourceLocation(BetterThanWeagles.MODID, "fish_heads"));
+	}
+
+	@SubscribeEvent
+	public void lootTableLoaded(LootTableLoadEvent event)
+	{
+		ResourceLocation poolName = event.getName();
+
+		String injectTablePath = "inject/" + poolName.getResourceDomain() + "/" + poolName.getResourcePath();
+
+		if (!LootTableInjector.INJECTED_LOOT_TABLES.contains(injectTablePath))
+		{
+			return;
+		}
+
+		LootTable injectTable = event.getLootTableManager().getLootTableFromLocation(new ResourceLocation(BetterThanWeagles.MODID, injectTablePath));
+		for (int i = 0; i < LootTableInjector.MAX_POOLS; i++)
+		{
+			LootPool pool = injectTable.getPool(String.format("inject%d", i));
+			if (pool != null)
+			{
+				event.getTable().addPool(pool);
+			}
+		}
+	}
+}

--- a/src/main/java/net/darkmorford/btweagles/item/ItemJellyBean.java
+++ b/src/main/java/net/darkmorford/btweagles/item/ItemJellyBean.java
@@ -1,6 +1,5 @@
 package net.darkmorford.btweagles.item;
 
-import javafx.util.Pair;
 import net.darkmorford.btweagles.BetterThanWeagles;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.entity.player.EntityPlayer;
@@ -13,6 +12,7 @@ import net.minecraft.world.World;
 import net.minecraftforge.client.model.ModelLoader;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import org.apache.commons.lang3.tuple.Pair;
 
 import java.util.ArrayList;
 
@@ -29,33 +29,33 @@ public class ItemJellyBean extends ItemFood
 		setUnlocalizedName("jelly_bean");
 		setCreativeTab(BetterThanWeagles.tabBTWeagles);
 
-		beanEffects.add(new Pair<>(MobEffects.SPEED, 100));
-		beanEffects.add(new Pair<>(MobEffects.SLOWNESS, 100));
-		beanEffects.add(new Pair<>(MobEffects.HASTE, 100));
-		beanEffects.add(new Pair<>(MobEffects.MINING_FATIGUE, 100));
-		beanEffects.add(new Pair<>(MobEffects.STRENGTH, 100));
-		beanEffects.add(new Pair<>(MobEffects.INSTANT_HEALTH, 100));
-		beanEffects.add(new Pair<>(MobEffects.INSTANT_DAMAGE, 100));
-		beanEffects.add(new Pair<>(MobEffects.JUMP_BOOST, 100));
-		beanEffects.add(new Pair<>(MobEffects.NAUSEA, 100));
-		beanEffects.add(new Pair<>(MobEffects.REGENERATION, 100));
-		beanEffects.add(new Pair<>(MobEffects.RESISTANCE, 100));
-		beanEffects.add(new Pair<>(MobEffects.FIRE_RESISTANCE, 100));
-		beanEffects.add(new Pair<>(MobEffects.WATER_BREATHING, 100));
-		beanEffects.add(new Pair<>(MobEffects.INVISIBILITY, 100));
-		beanEffects.add(new Pair<>(MobEffects.BLINDNESS, 100));
-		beanEffects.add(new Pair<>(MobEffects.NIGHT_VISION, 100));
-		beanEffects.add(new Pair<>(MobEffects.HUNGER, 100));
-		beanEffects.add(new Pair<>(MobEffects.WEAKNESS, 100));
-		beanEffects.add(new Pair<>(MobEffects.POISON, 100));
-		beanEffects.add(new Pair<>(MobEffects.WITHER, 100));
-		beanEffects.add(new Pair<>(MobEffects.HEALTH_BOOST, 100));
-		beanEffects.add(new Pair<>(MobEffects.ABSORPTION, 100));
-		beanEffects.add(new Pair<>(MobEffects.SATURATION, 100));
-		beanEffects.add(new Pair<>(MobEffects.GLOWING, 100));
-		beanEffects.add(new Pair<>(MobEffects.LEVITATION, 100));
-		beanEffects.add(new Pair<>(MobEffects.LUCK, 100));
-		beanEffects.add(new Pair<>(MobEffects.UNLUCK, 100));
+		beanEffects.add(Pair.of(MobEffects.SPEED, 100));
+		beanEffects.add(Pair.of(MobEffects.SLOWNESS, 100));
+		beanEffects.add(Pair.of(MobEffects.HASTE, 100));
+		beanEffects.add(Pair.of(MobEffects.MINING_FATIGUE, 100));
+		beanEffects.add(Pair.of(MobEffects.STRENGTH, 100));
+		beanEffects.add(Pair.of(MobEffects.INSTANT_HEALTH, 100));
+		beanEffects.add(Pair.of(MobEffects.INSTANT_DAMAGE, 100));
+		beanEffects.add(Pair.of(MobEffects.JUMP_BOOST, 100));
+		beanEffects.add(Pair.of(MobEffects.NAUSEA, 100));
+		beanEffects.add(Pair.of(MobEffects.REGENERATION, 100));
+		beanEffects.add(Pair.of(MobEffects.RESISTANCE, 100));
+		beanEffects.add(Pair.of(MobEffects.FIRE_RESISTANCE, 100));
+		beanEffects.add(Pair.of(MobEffects.WATER_BREATHING, 100));
+		beanEffects.add(Pair.of(MobEffects.INVISIBILITY, 100));
+		beanEffects.add(Pair.of(MobEffects.BLINDNESS, 100));
+		beanEffects.add(Pair.of(MobEffects.NIGHT_VISION, 100));
+		beanEffects.add(Pair.of(MobEffects.HUNGER, 100));
+		beanEffects.add(Pair.of(MobEffects.WEAKNESS, 100));
+		beanEffects.add(Pair.of(MobEffects.POISON, 100));
+		beanEffects.add(Pair.of(MobEffects.WITHER, 100));
+		beanEffects.add(Pair.of(MobEffects.HEALTH_BOOST, 100));
+		beanEffects.add(Pair.of(MobEffects.ABSORPTION, 100));
+		beanEffects.add(Pair.of(MobEffects.SATURATION, 100));
+		beanEffects.add(Pair.of(MobEffects.GLOWING, 100));
+		beanEffects.add(Pair.of(MobEffects.LEVITATION, 100));
+		beanEffects.add(Pair.of(MobEffects.LUCK, 100));
+		beanEffects.add(Pair.of(MobEffects.UNLUCK, 100));
 	}
 
 	@SideOnly(Side.CLIENT)

--- a/src/main/resources/assets/btweagles/loot_tables/fish_heads.json
+++ b/src/main/resources/assets/btweagles/loot_tables/fish_heads.json
@@ -1,0 +1,74 @@
+{
+    "pools": [
+        {
+            "name": "btweagles:fish_heads",
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagels:fish_head",
+                    "weight": 40,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Fish Head\"},SkullOwner:{Id:\"8f718637-6901-4301-bd98-ebde0cc19ed8\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNmY5OWI1ODBkNDVhNzg0ZTdhOTY0ZTdkM2IxZjk3Y2VjZTc0OTExMTczYmQyMWMxZDdjNTZhY2RjMzg1ZWQ1In19fQ==\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagels:salmon_head",
+                    "weight": 30,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Salmon Head\"},SkullOwner:{Id:\"e246c06c-5d6a-4fd9-b600-c6bd71336b7a\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYWRmYzU3ZDA5MDU5ZTQ3OTlmYTkyYzE1ZTI4NTEyYmNmYWExMzE1NTc3ZmUzYTI3YWVkMzg5ZTRmNzUyMjg5YSJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagels:clownfish_head",
+                    "weight": 10,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Clownfish Head\"},SkullOwner:{Id:\"7b314fba-09ab-4ab6-b956-cec6a5fcbed5\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzZkMTQ5ZTRkNDk5OTI5NjcyZTI3Njg5NDllNjQ3Nzk1OWMyMWU2NTI1NDYxM2IzMjdiNTM4ZGYxZTRkZiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagels:pufferfish_head",
+                    "weight": 20,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Pufferfish Head\"},SkullOwner:{Id:\"b4630012-0e65-4a3d-bfd6-5024b782ab69\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYTk1NTkzODg5OTNmZTc4MmY2N2JkNThkOThjNGRmNTZiY2Q0MzBlZGNiMmY2NmVmNTc3N2E3M2MyN2RlMyJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/fish_heads.json
+++ b/src/main/resources/assets/btweagles/loot_tables/fish_heads.json
@@ -7,7 +7,7 @@
                 {
                     "type": "item",
                     "name": "minecraft:skull",
-                    "entryName": "btweagels:fish_head",
+                    "entryName": "btweagles:fish_head",
                     "weight": 40,
                     "functions": [
                         {
@@ -23,7 +23,7 @@
                 {
                     "type": "item",
                     "name": "minecraft:skull",
-                    "entryName": "btweagels:salmon_head",
+                    "entryName": "btweagles:salmon_head",
                     "weight": 30,
                     "functions": [
                         {
@@ -39,7 +39,7 @@
                 {
                     "type": "item",
                     "name": "minecraft:skull",
-                    "entryName": "btweagels:clownfish_head",
+                    "entryName": "btweagles:clownfish_head",
                     "weight": 10,
                     "functions": [
                         {
@@ -55,7 +55,7 @@
                 {
                     "type": "item",
                     "name": "minecraft:skull",
-                    "entryName": "btweagels:pufferfish_head",
+                    "entryName": "btweagles:pufferfish_head",
                     "weight": 20,
                     "functions": [
                         {

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/abandoned_mineshaft.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/abandoned_mineshaft.json
@@ -1,0 +1,65 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "rolls": {
+                "min": 1,
+                "max": 1
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:alex_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"d46798ef-edd2-4b75-95fc-c1760972a079\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjNiMDk4OTY3MzQwZGFhYzUyOTI5M2MyNGUwNDkxMDUwOWIyMDhlN2I5NDU2M2MzZWYzMWRlYzdiMzc1MCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:steve_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"9f093fb6-bcd7-4c0a-aff0-79260f8bbc0c\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWI3YWY5ZTQ0MTEyMTdjN2RlOWM2MGFjYmQzYzNmZDY1MTk3ODMzMzJhMWIzYmM1NmZiZmNlOTA3MjFlZjM1In19fQ==\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:error_skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"ERROR\"},SkullOwner:{Id:\"d0b15454-36fa-43e4-a247-f882bb9fe288\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOThiN2NhM2M3ZDMxNGE2MWFiZWQ4ZmMxOGQ3OTdmYzMwYjZlZmM4NDQ1NDI1YzRlMjUwOTk3ZTUyZTZjYiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "empty",
+                    "weight": 1000
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/desert_pyramid.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/desert_pyramid.json
@@ -1,0 +1,65 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "rolls": {
+                "min": 1,
+                "max": 1
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:alex_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"d46798ef-edd2-4b75-95fc-c1760972a079\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjNiMDk4OTY3MzQwZGFhYzUyOTI5M2MyNGUwNDkxMDUwOWIyMDhlN2I5NDU2M2MzZWYzMWRlYzdiMzc1MCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:steve_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"9f093fb6-bcd7-4c0a-aff0-79260f8bbc0c\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWI3YWY5ZTQ0MTEyMTdjN2RlOWM2MGFjYmQzYzNmZDY1MTk3ODMzMzJhMWIzYmM1NmZiZmNlOTA3MjFlZjM1In19fQ==\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:error_skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"ERROR\"},SkullOwner:{Id:\"d0b15454-36fa-43e4-a247-f882bb9fe288\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOThiN2NhM2M3ZDMxNGE2MWFiZWQ4ZmMxOGQ3OTdmYzMwYjZlZmM4NDQ1NDI1YzRlMjUwOTk3ZTUyZTZjYiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "empty",
+                    "weight": 1000
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/end_city_treasure.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/end_city_treasure.json
@@ -1,0 +1,65 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "rolls": {
+                "min": 1,
+                "max": 1
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:alex_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"d46798ef-edd2-4b75-95fc-c1760972a079\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjNiMDk4OTY3MzQwZGFhYzUyOTI5M2MyNGUwNDkxMDUwOWIyMDhlN2I5NDU2M2MzZWYzMWRlYzdiMzc1MCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:steve_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"9f093fb6-bcd7-4c0a-aff0-79260f8bbc0c\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWI3YWY5ZTQ0MTEyMTdjN2RlOWM2MGFjYmQzYzNmZDY1MTk3ODMzMzJhMWIzYmM1NmZiZmNlOTA3MjFlZjM1In19fQ==\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:error_skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"ERROR\"},SkullOwner:{Id:\"d0b15454-36fa-43e4-a247-f882bb9fe288\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOThiN2NhM2M3ZDMxNGE2MWFiZWQ4ZmMxOGQ3OTdmYzMwYjZlZmM4NDQ1NDI1YzRlMjUwOTk3ZTUyZTZjYiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "empty",
+                    "weight": 1000
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/igloo_chest.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/igloo_chest.json
@@ -1,0 +1,65 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "rolls": {
+                "min": 1,
+                "max": 1
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:alex_skull",
+                    "weight": 50,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"d46798ef-edd2-4b75-95fc-c1760972a079\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjNiMDk4OTY3MzQwZGFhYzUyOTI5M2MyNGUwNDkxMDUwOWIyMDhlN2I5NDU2M2MzZWYzMWRlYzdiMzc1MCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:steve_skull",
+                    "weight": 50,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"9f093fb6-bcd7-4c0a-aff0-79260f8bbc0c\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWI3YWY5ZTQ0MTEyMTdjN2RlOWM2MGFjYmQzYzNmZDY1MTk3ODMzMzJhMWIzYmM1NmZiZmNlOTA3MjFlZjM1In19fQ==\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:error_skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"ERROR\"},SkullOwner:{Id:\"d0b15454-36fa-43e4-a247-f882bb9fe288\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOThiN2NhM2M3ZDMxNGE2MWFiZWQ4ZmMxOGQ3OTdmYzMwYjZlZmM4NDQ1NDI1YzRlMjUwOTk3ZTUyZTZjYiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "empty",
+                    "weight": 100
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/jungle_temple.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/jungle_temple.json
@@ -1,0 +1,65 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "rolls": {
+                "min": 1,
+                "max": 1
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:alex_skull",
+                    "weight": 50,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"d46798ef-edd2-4b75-95fc-c1760972a079\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjNiMDk4OTY3MzQwZGFhYzUyOTI5M2MyNGUwNDkxMDUwOWIyMDhlN2I5NDU2M2MzZWYzMWRlYzdiMzc1MCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:steve_skull",
+                    "weight": 50,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"9f093fb6-bcd7-4c0a-aff0-79260f8bbc0c\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWI3YWY5ZTQ0MTEyMTdjN2RlOWM2MGFjYmQzYzNmZDY1MTk3ODMzMzJhMWIzYmM1NmZiZmNlOTA3MjFlZjM1In19fQ==\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:error_skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"ERROR\"},SkullOwner:{Id:\"d0b15454-36fa-43e4-a247-f882bb9fe288\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOThiN2NhM2M3ZDMxNGE2MWFiZWQ4ZmMxOGQ3OTdmYzMwYjZlZmM4NDQ1NDI1YzRlMjUwOTk3ZTUyZTZjYiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "empty",
+                    "weight": 100
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/nether_bridge.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/nether_bridge.json
@@ -1,0 +1,65 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "rolls": {
+                "min": 1,
+                "max": 1
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:alex_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"d46798ef-edd2-4b75-95fc-c1760972a079\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjNiMDk4OTY3MzQwZGFhYzUyOTI5M2MyNGUwNDkxMDUwOWIyMDhlN2I5NDU2M2MzZWYzMWRlYzdiMzc1MCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:steve_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"9f093fb6-bcd7-4c0a-aff0-79260f8bbc0c\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWI3YWY5ZTQ0MTEyMTdjN2RlOWM2MGFjYmQzYzNmZDY1MTk3ODMzMzJhMWIzYmM1NmZiZmNlOTA3MjFlZjM1In19fQ==\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:error_skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"ERROR\"},SkullOwner:{Id:\"d0b15454-36fa-43e4-a247-f882bb9fe288\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOThiN2NhM2M3ZDMxNGE2MWFiZWQ4ZmMxOGQ3OTdmYzMwYjZlZmM4NDQ1NDI1YzRlMjUwOTk3ZTUyZTZjYiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "empty",
+                    "weight": 1000
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/simple_dungeon.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/simple_dungeon.json
@@ -1,0 +1,65 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "rolls": {
+                "min": 1,
+                "max": 1
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:alex_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"d46798ef-edd2-4b75-95fc-c1760972a079\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjNiMDk4OTY3MzQwZGFhYzUyOTI5M2MyNGUwNDkxMDUwOWIyMDhlN2I5NDU2M2MzZWYzMWRlYzdiMzc1MCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:steve_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"9f093fb6-bcd7-4c0a-aff0-79260f8bbc0c\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWI3YWY5ZTQ0MTEyMTdjN2RlOWM2MGFjYmQzYzNmZDY1MTk3ODMzMzJhMWIzYmM1NmZiZmNlOTA3MjFlZjM1In19fQ==\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:error_skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"ERROR\"},SkullOwner:{Id:\"d0b15454-36fa-43e4-a247-f882bb9fe288\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOThiN2NhM2M3ZDMxNGE2MWFiZWQ4ZmMxOGQ3OTdmYzMwYjZlZmM4NDQ1NDI1YzRlMjUwOTk3ZTUyZTZjYiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "empty",
+                    "weight": 1000
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/stronghold_corridor.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/stronghold_corridor.json
@@ -1,0 +1,65 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "rolls": {
+                "min": 1,
+                "max": 1
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:alex_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"d46798ef-edd2-4b75-95fc-c1760972a079\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjNiMDk4OTY3MzQwZGFhYzUyOTI5M2MyNGUwNDkxMDUwOWIyMDhlN2I5NDU2M2MzZWYzMWRlYzdiMzc1MCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:steve_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"9f093fb6-bcd7-4c0a-aff0-79260f8bbc0c\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWI3YWY5ZTQ0MTEyMTdjN2RlOWM2MGFjYmQzYzNmZDY1MTk3ODMzMzJhMWIzYmM1NmZiZmNlOTA3MjFlZjM1In19fQ==\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:error_skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"ERROR\"},SkullOwner:{Id:\"d0b15454-36fa-43e4-a247-f882bb9fe288\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOThiN2NhM2M3ZDMxNGE2MWFiZWQ4ZmMxOGQ3OTdmYzMwYjZlZmM4NDQ1NDI1YzRlMjUwOTk3ZTUyZTZjYiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "empty",
+                    "weight": 500
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/stronghold_crossing.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/stronghold_crossing.json
@@ -1,0 +1,65 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "rolls": {
+                "min": 1,
+                "max": 1
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:alex_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"d46798ef-edd2-4b75-95fc-c1760972a079\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjNiMDk4OTY3MzQwZGFhYzUyOTI5M2MyNGUwNDkxMDUwOWIyMDhlN2I5NDU2M2MzZWYzMWRlYzdiMzc1MCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:steve_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"9f093fb6-bcd7-4c0a-aff0-79260f8bbc0c\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWI3YWY5ZTQ0MTEyMTdjN2RlOWM2MGFjYmQzYzNmZDY1MTk3ODMzMzJhMWIzYmM1NmZiZmNlOTA3MjFlZjM1In19fQ==\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:error_skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"ERROR\"},SkullOwner:{Id:\"d0b15454-36fa-43e4-a247-f882bb9fe288\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOThiN2NhM2M3ZDMxNGE2MWFiZWQ4ZmMxOGQ3OTdmYzMwYjZlZmM4NDQ1NDI1YzRlMjUwOTk3ZTUyZTZjYiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "empty",
+                    "weight": 500
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/stronghold_library.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/stronghold_library.json
@@ -1,0 +1,65 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "rolls": {
+                "min": 1,
+                "max": 1
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:alex_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"d46798ef-edd2-4b75-95fc-c1760972a079\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjNiMDk4OTY3MzQwZGFhYzUyOTI5M2MyNGUwNDkxMDUwOWIyMDhlN2I5NDU2M2MzZWYzMWRlYzdiMzc1MCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:steve_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"9f093fb6-bcd7-4c0a-aff0-79260f8bbc0c\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWI3YWY5ZTQ0MTEyMTdjN2RlOWM2MGFjYmQzYzNmZDY1MTk3ODMzMzJhMWIzYmM1NmZiZmNlOTA3MjFlZjM1In19fQ==\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:error_skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"ERROR\"},SkullOwner:{Id:\"d0b15454-36fa-43e4-a247-f882bb9fe288\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOThiN2NhM2M3ZDMxNGE2MWFiZWQ4ZmMxOGQ3OTdmYzMwYjZlZmM4NDQ1NDI1YzRlMjUwOTk3ZTUyZTZjYiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "empty",
+                    "weight": 500
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/village_blacksmith.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/village_blacksmith.json
@@ -1,0 +1,65 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "rolls": {
+                "min": 1,
+                "max": 1
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:alex_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"d46798ef-edd2-4b75-95fc-c1760972a079\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjNiMDk4OTY3MzQwZGFhYzUyOTI5M2MyNGUwNDkxMDUwOWIyMDhlN2I5NDU2M2MzZWYzMWRlYzdiMzc1MCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:steve_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"9f093fb6-bcd7-4c0a-aff0-79260f8bbc0c\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWI3YWY5ZTQ0MTEyMTdjN2RlOWM2MGFjYmQzYzNmZDY1MTk3ODMzMzJhMWIzYmM1NmZiZmNlOTA3MjFlZjM1In19fQ==\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:error_skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"ERROR\"},SkullOwner:{Id:\"d0b15454-36fa-43e4-a247-f882bb9fe288\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOThiN2NhM2M3ZDMxNGE2MWFiZWQ4ZmMxOGQ3OTdmYzMwYjZlZmM4NDQ1NDI1YzRlMjUwOTk3ZTUyZTZjYiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "empty",
+                    "weight": 500
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/woodland_mansion.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/chests/woodland_mansion.json
@@ -1,0 +1,65 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "rolls": {
+                "min": 1,
+                "max": 1
+            },
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:alex_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"d46798ef-edd2-4b75-95fc-c1760972a079\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjNiMDk4OTY3MzQwZGFhYzUyOTI5M2MyNGUwNDkxMDUwOWIyMDhlN2I5NDU2M2MzZWYzMWRlYzdiMzc1MCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "entryName": "btweagles:steve_skull",
+                    "weight": 250,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Player Head\"},SkullOwner:{Id:\"9f093fb6-bcd7-4c0a-aff0-79260f8bbc0c\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZWI3YWY5ZTQ0MTEyMTdjN2RlOWM2MGFjYmQzYzNmZDY1MTk3ODMzMzJhMWIzYmM1NmZiZmNlOTA3MjFlZjM1In19fQ==\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "item",
+                    "entryName": "btweagles:error_skull",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"ERROR\"},SkullOwner:{Id:\"d0b15454-36fa-43e4-a247-f882bb9fe288\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOThiN2NhM2M3ZDMxNGE2MWFiZWQ4ZmMxOGQ3OTdmYzMwYjZlZmM4NDQ1NDI1YzRlMjUwOTk3ZTUyZTZjYiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                },
+                {
+                    "type": "empty",
+                    "weight": 500
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/bat.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/bat.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.02,
+                    "looting_multiplier": 0.02
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Bat Head\"},SkullOwner:{Id:\"e2d4c388-42d5-4a96-b4c9-623df7f5e026\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNGNmMWIzYjNmNTM5ZDJmNjNjMTcyZTk0Y2FjZmFhMzkxZThiMzg1Y2RkNjMzZjNiOTkxYzc0ZTQ0YjI4In19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/blaze.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/blaze.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.001,
+                    "looting_multiplier": 0.0005
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Blaze Head\"},SkullOwner:{Id:\"7ceb88b2-7f5f-4399-abb9-7068251baa9d\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjc4ZWYyZTRjZjJjNDFhMmQxNGJmZGU5Y2FmZjEwMjE5ZjViMWJmNWIzNWE0OWViNTFjNjQ2Nzg4MmNiNWYwIn19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/cave_spider.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/cave_spider.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.001,
+                    "looting_multiplier": 0.001
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Cave Spider Head\"},SkullOwner:{Id:\"39173a7a-c957-4ec1-ac1a-43e5a64983df\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDE2NDVkZmQ3N2QwOTkyMzEwN2IzNDk2ZTk0ZWViNWMzMDMyOWY5N2VmYzk2ZWQ3NmUyMjZlOTgyMjQifX19\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/chicken.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/chicken.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.005,
+                    "looting_multiplier": 0.001
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Chicken Head\"},SkullOwner:{Id:\"7d3a8ace-e045-4eba-ab71-71dbf525daf1\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTYzODQ2OWE1OTljZWVmNzIwNzUzNzYwMzI0OGE5YWIxMWZmNTkxZmQzNzhiZWE0NzM1YjM0NmE3ZmFlODkzIn19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/cow.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/cow.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.005,
+                    "looting_multiplier": 0.001
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Cow Head\"},SkullOwner:{Id:\"97ddf3b3-9dbe-4a3b-8a0f-1b19ddeac0bd\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNWQ2YzZlZGE5NDJmN2Y1ZjcxYzMxNjFjNzMwNmY0YWVkMzA3ZDgyODk1ZjlkMmIwN2FiNDUyNTcxOGVkYzUifX19\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/donkey.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/donkey.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.02,
+                    "looting_multiplier": 0.01
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Donkey Head\"},SkullOwner:{Id:\"1139f336-6575-4e51-a762-3baebb4dd2d0\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGZiNmMzYzA1MmNmNzg3ZDIzNmEyOTE1ZjgwNzJiNzdjNTQ3NDk3NzE1ZDFkMmY4Y2JjOWQyNDFkODhhIn19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/elder_guardian.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/elder_guardian.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.3,
+                    "looting_multiplier": 0.05
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Elder Guardian Head\"},SkullOwner:{Id:\"f2e933a7-614f-44e0-bf18-289b102104ab\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMWM3OTc0ODJhMTRiZmNiODc3MjU3Y2IyY2ZmMWI2ZTZhOGI4NDEzMzM2ZmZiNGMyOWE2MTM5Mjc4YjQzNmIifX19\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/ender_dragon.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/ender_dragon.json
@@ -1,0 +1,56 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:elytra",
+                    "weight": 1
+                }
+            ]
+        },
+        {
+            "name": "inject1",
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 5
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "inject2",
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:dragon_egg",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_count",
+                            "count": 1
+                        },
+                        {
+                            "function": "looting_enchant",
+                            "count": {
+                                "min": 0,
+                                "max": 1
+                            }
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/enderman.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/enderman.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0002,
+                    "looting_multiplier": 0.0001
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Enderman Head\"},SkullOwner:{Id:\"0de98464-1274-4dd6-bba8-370efa5d41a8\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvN2E1OWJiMGE3YTMyOTY1YjNkOTBkOGVhZmE4OTlkMTgzNWY0MjQ1MDllYWRkNGU2YjcwOWFkYTUwYjljZiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/endermite.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/endermite.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.02,
+                    "looting_multiplier": 0.01
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Endermite Head\"},SkullOwner:{Id:\"33c425bb-a294-4e01-9b5b-a8ad652bb5cf\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODRhYWZmYTRjMDllMmVhZmI4NWQzNTIyMTIyZGIwYWE0NTg3NGJlYTRlM2Y1ZTc1NjZiNGQxNjZjN2RmOCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/evocation_illager.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/evocation_illager.json
@@ -1,0 +1,25 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Evoker Head\"},SkullOwner:{Id:\"36ee7e5b-c092-48ad-9673-2a73b0a44b4f\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYTAwZDNmZmYxNmMyZGNhNTliOWM1OGYwOTY1MjVjODY5NzExNjZkYmFlMTMzYjFiMDUwZTVlZTcxNjQ0MyJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/ghast.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/ghast.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.05,
+                    "looting_multiplier": 0.025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Ghast Head\"},SkullOwner:{Id:\"807f287f-6499-4e93-a887-0a298ab3091f\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOGI2YTcyMTM4ZDY5ZmJiZDJmZWEzZmEyNTFjYWJkODcxNTJlNGYxYzk3ZTVmOTg2YmY2ODU1NzFkYjNjYzAifX19\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/guardian.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/guardian.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.002,
+                    "looting_multiplier": 0.001
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Mini Guardian\"},SkullOwner:{Id:\"e57e58c0-bb9c-4cb0-a0a2-c137dfc91164\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGZiNjc1Y2I1YTdlM2ZkMjVlMjlkYTgyNThmMjRmYzAyMGIzZmE5NTAzNjJiOGJjOGViMjUyZTU2ZTc0In19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/husk.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/husk.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.03,
+                    "looting_multiplier": 0.01
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Husk Head\"},SkullOwner:{Id:\"2e387bc6-774b-4fda-ba22-eb54a26dfd9e\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzc3MDY4MWQxYTI1NWZiNGY3NTQ3OTNhYTA1NWIyMjA0NDFjZGFiOWUxMTQxZGZhNTIzN2I0OTkzMWQ5YjkxYyJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/iron_golem.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/iron_golem.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.02,
+                    "looting_multiplier": 0.01
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Iron Golem Head\"},SkullOwner:{Id:\"7cb6e9a5-994f-40d5-9bfc-4ba5d796d21e\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODkwOTFkNzllYTBmNTllZjdlZjk0ZDdiYmE2ZTVmMTdmMmY3ZDQ1NzJjNDRmOTBmNzZjNDgxOWE3MTQifX19\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/magma_cube.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/magma_cube.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.005,
+                    "looting_multiplier": 0.001
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Magma Cube Head\"},SkullOwner:{Id:\"96aced64-5b85-4b99-b825-53cd7a9f9726\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzg5NTdkNTAyM2M5MzdjNGM0MWFhMjQxMmQ0MzQxMGJkYTIzY2Y3OWE5ZjZhYjM2Yjc2ZmVmMmQ3YzQyOSJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/mushroom_cow.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/mushroom_cow.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.002,
+                    "looting_multiplier": 0.001
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Mooshroom Head\"},SkullOwner:{Id:\"e206ac29-ae69-475b-909a-fb523d894336\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZDBiYzYxYjk3NTdhN2I4M2UwM2NkMjUwN2EyMTU3OTEzYzJjZjAxNmU3YzA5NmE0ZDZjZjFmZTFiOGRiIn19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/pig.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/pig.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.005,
+                    "looting_multiplier": 0.001
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Pig Head\"},SkullOwner:{Id:\"e1e1c2e4-1ed2-473d-bde2-3ec718535399\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjIxNjY4ZWY3Y2I3OWRkOWMyMmNlM2QxZjNmNGNiNmUyNTU5ODkzYjZkZjRhNDY5NTE0ZTY2N2MxNmFhNCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/polar_bear.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/polar_bear.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.1,
+                    "looting_multiplier": 0.05
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Polar Bear Head\"},SkullOwner:{Id:\"87324464-1700-468f-8333-e7779ec8c21e\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZDQ2ZDIzZjA0ODQ2MzY5ZmEyYTM3MDJjMTBmNzU5MTAxYWY3YmZlODQxOTk2NjQyOTUzM2NkODFhMTFkMmIifX19\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/black.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/black.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Black Sheep Head\"},SkullOwner:{Id:\"f6801465-fd07-47f9-92a1-3ae921c3ef05\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzI2NTIwODNmMjhlZDFiNjFmOWI5NjVkZjFhYmYwMTBmMjM0NjgxYzIxNDM1OTUxYzY3ZDg4MzY0NzQ5ODIyIn19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/blue.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/blue.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Blue Sheep Head\"},SkullOwner:{Id:\"dc501290-d6f2-4fc2-a4c3-b4de68fbb395\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZDllYzIyODE4ZDFmYmZjODE2N2ZiZTM2NzI4YjI4MjQwZTM0ZTE2NDY5YTI5MjlkMDNmZGY1MTFiZjJjYTEifX19\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/brown.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/brown.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Brown Sheep Head\"},SkullOwner:{Id:\"68f33306-b8e2-472b-984e-6a05ecb32d63\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYTU1YWQ2ZTVkYjU2OTJkODdmNTE1MTFmNGUwOWIzOWZmOWNjYjNkZTdiNDgxOWE3Mzc4ZmNlODU1M2I4In19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/cyan.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/cyan.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Cyan Sheep Head\"},SkullOwner:{Id:\"6484f6d0-03c5-4c88-b121-c776dd24e6b4\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDZmNmM3ZTdmZDUxNGNlMGFjYzY4NTkzMjI5ZTQwZmNjNDM1MmI4NDE2NDZlNGYwZWJjY2NiMGNlMjNkMTYifX19\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/gray.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/gray.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Gray Sheep Head\"},SkullOwner:{Id:\"1ad6a380-fd48-43e0-a7ea-5685072f37b6\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDI4N2ViNTAxMzkxZjI3NTM4OWYxNjZlYzlmZWJlYTc1ZWM0YWU5NTFiODhiMzhjYWU4N2RmN2UyNGY0YyJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/green.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/green.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Green Sheep Head\"},SkullOwner:{Id:\"710d1cc5-d61c-415b-b4a6-658d1e5652e8\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYTAxNzIxNWM3ZjhkYjgyMDQwYWEyYzQ3Mjk4YjY2NTQxYzJlYjVmN2Y5MzA0MGE1ZDIzZDg4ZjA2ODdkNGIzNCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/light_blue.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/light_blue.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Light Blue Sheep Head\"},SkullOwner:{Id:\"f6ad6acf-aabe-45ac-94bb-d67b9dfdcc63\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMWM4YTk3YTM4ODU2NTE0YTE2NDEzZTJjOTk1MjEyODlmNGM1MzYzZGM4MmZjOWIyODM0Y2ZlZGFjNzhiODkifX19\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/lime.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/lime.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Lime Sheep Head\"},SkullOwner:{Id:\"2d1afbe7-9651-45f7-bf6e-fa7647ed6a42\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTJhMjQ0OGY1OGE0OTEzMzI0MzRlODVjNDVkNzg2ZDg3NDM5N2U4MzBhM2E3ODk0ZTZkOTI2OTljNDJiMzAifX19\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/magenta.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/magenta.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Magenta Sheep Head\"},SkullOwner:{Id:\"df42f9f2-86ef-488e-874a-7f8438f56d56\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTgzNjU2NWM3ODk3ZDQ5YTcxYmMxODk4NmQxZWE2NTYxMzIxYTBiYmY3MTFkNDFhNTZjZTNiYjJjMjE3ZTdhIn19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/orange.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/orange.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Orange Sheep Head\"},SkullOwner:{Id:\"c1cde30f-88ad-4d05-a278-6dd2bae9a500\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZjA5ODM5N2EyNzBiNGMzZDJiMWU1NzRiOGNmZDNjYzRlYTM0MDkwNjZjZWZlMzFlYTk5MzYzM2M5ZDU3NiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/pink.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/pink.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Pink Sheep Head\"},SkullOwner:{Id:\"b7df2ea8-b576-4386-8026-7df2af1051f1\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMmFjNzRhMmI5YjkxNDUyZTU2ZmExZGRhNWRiODEwNzc4NTZlNDlmMjdjNmUyZGUxZTg0MWU1Yzk1YTZmYzVhYiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/purple.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/purple.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Purple Sheep Head\"},SkullOwner:{Id:\"ff5c1932-8096-4751-bbcf-7e0d8837b8c1\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYWU1Mjg2N2FmZWYzOGJiMTRhMjZkMTQyNmM4YzBmMTE2YWQzNDc2MWFjZDkyZTdhYWUyYzgxOWEwZDU1Yjg1In19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/red.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/red.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Red Sheep Head\"},SkullOwner:{Id:\"b2386bba-3c78-456c-bc90-a9716cec93bd\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODM5YWY0NzdlYjYyNzgxNWY3MjNhNTY2MjU1NmVjOWRmY2JhYjVkNDk0ZDMzOGJkMjE0MjMyZjIzZTQ0NiJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/silver.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/silver.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Light Gray Sheep Head\"},SkullOwner:{Id:\"97331797-cf17-4127-b250-4ec2e8cc0608\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2UxYWM2ODM5OTNiZTM1NTEyZTFiZTMxZDFmNGY5OGU1ODNlZGIxNjU4YTllMjExOTJjOWIyM2I1Y2NjZGMzIn19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/white.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/white.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Sheep Head\"},SkullOwner:{Id:\"fa234925-9dbe-4b8f-a544-7c70fb6b6ac5\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZjMxZjljY2M2YjNlMzJlY2YxM2I4YTExYWMyOWNkMzNkMThjOTVmYzczZGI4YTY2YzVkNjU3Y2NiOGJlNzAifX19\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/yellow.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/sheep/yellow.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0175,
+                    "looting_multiplier": 0.0025
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Yellow Sheep Head\"},SkullOwner:{Id:\"f4b4f889-4cdb-458e-8c86-50d91c4c1c89\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMjZhNDExMmRmMWU0YmNlMmE1ZTI4NDE3ZjNhYWZmNzljZDY2ZTg4NWMzNzI0NTU0MTAyY2VmOGViOCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/shulker.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/shulker.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.02,
+                    "looting_multiplier": 0.01
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Shulker Skull\"},SkullOwner:{Id:\"cda568d7-46da-4468-a46a-4c1ed73faf53\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMWU3MzgzMmUyNzJmODg0NGM0NzY4NDZiYzQyNGEzNDMyZmI2OThjNThlNmVmMmE5ODcxYzdkMjlhZWVhNyJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/silverfish.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/silverfish.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.02,
+                    "looting_multiplier": 0.01
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Silverfish Head\"},SkullOwner:{Id:\"30a4cd5c-5754-4db8-8960-18022a74627d\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGE5MWRhYjgzOTFhZjVmZGE1NGFjZDJjMGIxOGZiZDgxOWI4NjVlMWE4ZjFkNjIzODEzZmE3NjFlOTI0NTQwIn19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/slime.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/slime.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.0005,
+                    "looting_multiplier": 0.001
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Slime Head\"},SkullOwner:{Id:\"9aca565d-105c-4e8c-81fc-740545cb74b2\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTZhZDIwZmMyZDU3OWJlMjUwZDNkYjY1OWM4MzJkYTJiNDc4YTczYTY5OGI3ZWExMGQxOGM5MTYyZTRkOWI1In19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/snowman.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/snowman.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.02,
+                    "looting_multiplier": 0.01
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Snowman Head\"},SkullOwner:{Id:\"673db4c6-b7ea-421e-ae35-d7ab65e8b35e\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMWZkZmQxZjc1MzhjMDQwMjU4YmU3YTkxNDQ2ZGE4OWVkODQ1Y2M1ZWY3MjhlYjVlNjkwNTQzMzc4ZmNmNCJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/spider.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/spider.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.002,
+                    "looting_multiplier": 0.001
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Spider Head\"},SkullOwner:{Id:\"8bdb71d0-4724-48b2-9344-e79480424798\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2Q1NDE1NDFkYWFmZjUwODk2Y2QyNThiZGJkZDRjZjgwYzNiYTgxNjczNTcyNjA3OGJmZTM5MzkyN2U1N2YxIn19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/squid.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/squid.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.02,
+                    "looting_multiplier": 0.01
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Squid Head\"},SkullOwner:{Id:\"f95d9504-ea2b-4b89-b2d0-d400654a7010\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMDE0MzNiZTI0MjM2NmFmMTI2ZGE0MzRiODczNWRmMWViNWIzY2IyY2VkZTM5MTQ1OTc0ZTljNDgzNjA3YmFjIn19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/stray.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/stray.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.05,
+                    "looting_multiplier": 0.05
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Stray Head\"},SkullOwner:{Id:\"644c9bad-958b-43ce-9d2f-199d85be607c\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzhkZGY3NmU1NTVkZDVjNGFhOGEwYTVmYzU4NDUyMGNkNjNkNDg5YzI1M2RlOTY5ZjdmMjJmODVhOWEyZDU2In19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/vex.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/vex.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.02,
+                    "looting_multiplier": 0.01
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Vex Head\"},SkullOwner:{Id:\"f83bcfc1-0213-4957-888e-d3e2fae71203\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNWU3MzMwYzdkNWNkOGEwYTU1YWI5ZTk1MzIxNTM1YWM3YWUzMGZlODM3YzM3ZWE5ZTUzYmVhN2JhMmRlODZiIn19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/villager.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/villager.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.005,
+                    "looting_multiplier": 0.005
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Villager Head\"},SkullOwner:{Id:\"0a9e8efb-9191-4c81-80f5-e27ca5433156\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODIyZDhlNzUxYzhmMmZkNGM4OTQyYzQ0YmRiMmY1Y2E0ZDhhZThlNTc1ZWQzZWIzNGMxOGE4NmU5M2IifX19\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/vindication_illager.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/vindication_illager.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.1,
+                    "looting_multiplier": 0.05
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Vindicator Head\"},SkullOwner:{Id:\"36ee7e5b-c092-48ad-9673-2a73b0a44b4f\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYTAwZDNmZmYxNmMyZGNhNTliOWM1OGYwOTY1MjVjODY5NzExNjZkYmFlMTMzYjFiMDUwZTVlZTcxNjQ0MyJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/witch.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/witch.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.002,
+                    "looting_multiplier": 0.001
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Witch Head\"},SkullOwner:{Id:\"755dc254-690e-40cc-bdec-e290f4941efb\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODllOGI1ZjE1YTliMjlhMWUzODljOTUyMThmZDM3OTVmMzI4NzJlNWFlZTk0NjRhNzY0OTVjNTI3ZDIyNDUifX19\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/wolf.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/wolf.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.02,
+                    "looting_multiplier": 0.01
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Wolf Head\"},SkullOwner:{Id:\"9a7c65fb-309f-4c1a-96a1-4522c197b7fe\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZTk1Y2JiNGY3NWVhODc2MTdmMmY3MTNjNmQ0OWRhYzMyMDliYTFiZDRiOTM2OTY1NGIxNDU5ZWExNTMxNyJ9fX0=\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/zombie_pigman.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/entities/zombie_pigman.json
@@ -1,0 +1,35 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "conditions": [
+                {
+                    "condition": "killed_by_player"
+                },
+                {
+                    "condition": "random_chance_with_looting",
+                    "chance": 0.001,
+                    "looting_multiplier": 0.001
+                }
+            ],
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "item",
+                    "name": "minecraft:skull",
+                    "weight": 1,
+                    "functions": [
+                        {
+                            "function": "set_data",
+                            "data": 3
+                        },
+                        {
+                            "function": "set_nbt",
+                            "tag": "{display:{LocName:\"Zombie Pigman Head\"},SkullOwner:{Id:\"6540c046-d6ea-4aff-9766-32a54ebe6958\",Properties:{textures:[{Value:\"eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzRlOWM2ZTk4NTgyZmZkOGZmOGZlYjMzMjJjZDE4NDljNDNmYjE2YjE1OGFiYjExY2E3YjQyZWRhNzc0M2ViIn19fQ==\"}]}}}"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/gameplay/fishing.json
+++ b/src/main/resources/assets/btweagles/loot_tables/inject/minecraft/gameplay/fishing.json
@@ -1,0 +1,19 @@
+{
+    "pools": [
+        {
+            "name": "inject0",
+            "rolls": 1,
+            "entries": [
+                {
+                    "type": "empty",
+                    "weight": 499
+                },
+                {
+                    "type": "loot_table",
+                    "name": "btweagles:fish_heads",
+                    "weight": 1
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
More Mob Heads is implemented as a set of loot tables to inject to the default
loot tables. The only difference between More Mob Heads and the injected loot
tables is that the shulkers don't drop additional shells. The Ender Dragon
still drops elytras and dragon eggs.

Even More Mob Heads is implemented as a `LivingDropsEvent` listener and the
mob heads are hardcoded.

When rebasing I noticed that `javafx.util.Pair` seems to be missing on OpenJDK. I replaced it with `org.apache.commons.lang3.tuple.Pair`.

